### PR TITLE
[HYP-33858] Add workaround to setup eth1 on ro-rootfs

### DIFF
--- a/recipes-core/initrdscripts/files/hiposmount
+++ b/recipes-core/initrdscripts/files/hiposmount
@@ -92,4 +92,10 @@ hiposmount_run() {
 
     # Move keystore mount into new
     mount --move "$_MNT_KEYSTORE" "$ROOTFS_DIR$_MNT_KEYSTORE"
+
+    # HACKY: Workaround for eth1 setup
+    cp "${ROOTFS_DIR}/etc/network/interfaces" /tmp/interfaces
+    echo "iface eth1 inet dhcp" >> /tmp/interfaces
+    echo "allow-hotplug eth1" >> /tmp/interfaces
+    mount --bind /tmp/interfaces "${ROOTFS_DIR}/etc/network/interfaces"
 }

--- a/recipes-core/initrdscripts/files/hiposprovisioning
+++ b/recipes-core/initrdscripts/files/hiposprovisioning
@@ -161,4 +161,10 @@ hiposprovisioning_run() {
     mount --move "${_MNT_KEYSTORE}" "${ROOTFS_DIR}${_MNT_KEYSTORE}"
     mount --move "${_MNT_DATASTORE}" "${ROOTFS_DIR}${_MNT_DATASTORE}"
     mount --move "${_MNT_PROVISIONING}" "${ROOTFS_DIR}${_MNT_PROVISIONING}"
+
+    # HACKY: Workaround for eth1 setup
+    cp "${ROOTFS_DIR}/etc/network/interfaces" /tmp/interfaces
+    echo "iface eth1 inet dhcp" >> /tmp/interfaces
+    echo "allow-hotplug eth1" >> /tmp/interfaces
+    mount --bind /tmp/interfaces "${ROOTFS_DIR}/etc/network/interfaces"
 }


### PR DESCRIPTION
`/etc/network/interfaces` can not be updated by drconfig, so `eth1` will never be available. This hack does that in the initramfs stage.