### PR TITLE
hipos-cyber-security: fix secure build marker, HYP-34043

### DIFF
--- a/recipes-image/hipos/hipos-image.inc
+++ b/recipes-image/hipos/hipos-image.inc
@@ -15,8 +15,11 @@ IMAGE_INSTALL += "         \
     lighttpd-module-webdav \
 "
 
+
 # Marker file allowing scripts to distinguish secure builds from non-secure builds
-do_rootfs:append:hipos-cyber-security() {
+ROOTFS_POSTPROCESS_COMMAND:append:hipos-cyber-security = " add_hipos_secure_build_marker; "
+
+add_hipos_secure_build_marker() {
     install -d ${IMAGE_ROOTFS}${sysconfdir}
     echo "SECURE_BUILD=true" > ${IMAGE_ROOTFS}${sysconfdir}/hipos-build-info
 }


### PR DESCRIPTION
First commit was pushed accidentally without PL 
https://github.com/iris-GmbH/meta-hipos/commit/acc8a11ebd5ccaea87a8e8054d1ea3ab8a30e513

It allows scripts to check whether they are running on a secure build
`#!/bin/sh

BUILD_INFO=/etc/hipos-build-info

if [ -r "$BUILD_INFO" ]; then
    . "$BUILD_INFO"
fi

if [ "$SECURE_BUILD" = "true" ]; then
    echo "secure build"
else
    echo "non-secure build"
fi`